### PR TITLE
Added php-fpm www pool config configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ Also register a cron job for regular background working:
 oc process -f https://raw.githubusercontent.com/jngrb/nextcloud-openshift/master/nextcloud-cron.yaml | oc -n $PROJECT create -f -
 ```
 
+## Tweak php-fpm
+The OpenShift template automatically created a ConfigMap `fpm-confd` where you can set the php-fpm pool config. **Note:** You must restart the pod(s) to take the changes into effect.
+
+```[bash]
+[www]
+pm = dynamic
+pm.max_children = 120
+pm.start_servers = 12
+pm.min_spare_servers = 6
+pm.max_spare_servers = 18
+```
+
+```[bash]
+oc rollout latest dc/nextcloud
+```
+
 #### Template parameters
 
 Execute the following command to get the available parameters:

--- a/nextcloud.yaml
+++ b/nextcloud.yaml
@@ -203,6 +203,10 @@ objects:
           - mountPath: /var/www/html/custom_apps
             name: nextcloud-data
             subPath: apps
+          - mountPath: /usr/local/etc/php-fpm.d/www.overloaded.conf
+            name: fpm-confd
+            subPath: www.overloaded.conf
+            readOnly: true
         - image: nginx
           imagePullPolicy: Always
           livenessProbe:
@@ -249,6 +253,9 @@ objects:
         - name: nextcloud-data
           persistentVolumeClaim:
             claimName: nextcloud-data
+        - name: fpm-confd
+          configMap:
+            name: fpm-confd
     test: false
     triggers:
     - imageChangeParams:
@@ -301,3 +308,15 @@ objects:
       name: nextcloud
       weight: 100
     wildcardPolicy: None
+- apiVersion: v1
+  kind: ConfigMap
+  data:
+    www.overloaded.conf: |-
+        ;[www]
+        ;pm = dynamic
+        ;pm.max_children = 120
+        ;pm.start_servers = 12
+        ;pm.min_spare_servers = 6
+        ;pm.max_spare_servers = 18
+  metadata:
+    name: fpm-confd


### PR DESCRIPTION
This pullrequest adds a configmap to override the default www php-fpm pool. This allows to adjust the pool config settings without editing the pod/image itself