### PR TITLE
Nextcloud Cron 5 minute Schedule

### DIFF
--- a/nextcloud-cron.yaml
+++ b/nextcloud-cron.yaml
@@ -93,5 +93,5 @@ objects:
             - name: nextcloud-data
               persistentVolumeClaim:
                 claimName: nextcloud-data
-    schedule: '*/15 * * * *'
+    schedule: '*/5 * * * *'
     suspend: false


### PR DESCRIPTION
Changed the nextcloud cron task execution time to every 5 minutes. This is recommended in nextcloud docs